### PR TITLE
bug fix and add netcdf compression for 0_tools

### DIFF
--- a/0_tools/SUMMA_plot_computational_times.py
+++ b/0_tools/SUMMA_plot_computational_times.py
@@ -80,6 +80,9 @@ def get_computation_time(file,nLines=30):
     
     # get the file contents
     log_txt = tail(folder,file,nLines)
+
+    # initialize the return values. Negative values allows for filtering outside this function if needed
+    total = physics = write = read = restart = setup = init = -1
     
     # only proceed if simulation was successful
     success = False
@@ -90,10 +93,7 @@ def get_computation_time(file,nLines=30):
     if not success:
         print(f'{file} does not appear to log a successful SUMMA run. Skipping.')
         nSkipped += 1
-        return
-    
-    # initialize the return values. Negative values allows for filtering outside this function if needed
-    total = physics = write = read = restart = setup = init = -1
+        return total,physics,write,read,restart,setup,init,nSkipped
     
     # loop over the lines and act according to what's found in the line
     for line in log_txt:
@@ -122,7 +122,7 @@ def get_computation_time(file,nLines=30):
 
 # Remove the summar file if it exists
 try:
-    os.remove(folder + '/' + summaryFile)
+    os.remove(folder + '/' + summaryFig)
 except OSError:
     pass
     

--- a/0_tools/SUMMA_split_out_to_mizuRoute_split_in.sh
+++ b/0_tools/SUMMA_split_out_to_mizuRoute_split_in.sh
@@ -44,7 +44,7 @@ year=$1 # accepts year as input argument; disable this and enable FOR loop below
   ncrcat -O ${path_tym}/*.nc ${path_des}/run1_${year}${month}.nc
   
   # swap the dimensions again
-  ncpdq -O -a time,gru ${path_des}/run1_${year}${month}.nc ${path_des}/run1_${year}${month}.nc
+  ncpdq -O -L 1 -a time,gru ${path_des}/run1_${year}${month}.nc ${path_des}/run1_${year}${month}.nc
   
   # clean the temporary dir
   rm -r ${path_tym}


### PR DESCRIPTION
1. Fix two bugs (one empty return and one wrong variable name) in SUMMA_plot_computational_times.py.
2. Add netcdf deflate level 1 in SUMMA_split_out_to_mizuRoute_split_in.sh to reduce output file size.